### PR TITLE
Revert: Re-add leading slash to icon paths

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -18,30 +18,30 @@ async function updateIcon(state) {
             case 'active':
             case 'success':
                 iconPath = {
-                    "16": "assets/icons/icon_green.png",
-                    "48": "assets/icons/icon_green.png",
-                    "128": "assets/icons/icon_green.png"
+                    "16": "/assets/icons/icon_green.png",
+                    "48": "/assets/icons/icon_green.png",
+                    "128": "/assets/icons/icon_green.png"
                 };
                 break;
             case 'inactive':
                 iconPath = {
-                    "16": "assets/icons/icon_red.png",
-                    "48": "assets/icons/icon_red.png",
-                    "128": "assets/icons/icon_red.png"
+                    "16": "/assets/icons/icon_red.png",
+                    "48": "/assets/icons/icon_red.png",
+                    "128": "/assets/icons/icon_red.png"
                 };
                 break;
             case 'loading':
                 iconPath = {
-                    "16": "assets/icons/icon_loading.png",
-                    "48": "assets/icons/icon_loading.png",
-                    "128": "assets/icons/icon_loading.png"
+                    "16": "/assets/icons/icon_loading.png",
+                    "48": "/assets/icons/icon_loading.png",
+                    "128": "/assets/icons/icon_loading.png"
                 };
                 break;
             default:
                 iconPath = {
-                    "16": "assets/icons/icon_red.png",
-                    "48": "assets/icons/icon_red.png",
-                    "128": "assets/icons/icon_red.png"
+                    "16": "/assets/icons/icon_red.png",
+                    "48": "/assets/icons/icon_red.png",
+                    "128": "/assets/icons/icon_red.png"
                 }; // Fallback
         }
         await chrome.action.setIcon({ path: iconPath });


### PR DESCRIPTION
This reverts the previous change that removed the leading slash from the icon paths in `background.js`. The removal of the slash caused a "Failed to fetch" error, preventing the extension from loading the icon resources.

Re-introducing the leading slash makes the paths absolute to the extension's root directory, which is the correct way to reference them from a service worker. This should fix the icon update bug.