### PR TITLE
feat: Implement partial screenshot functionality

### DIFF
--- a/extension/content/capture.css
+++ b/extension/content/capture.css
@@ -1,0 +1,29 @@
+#screenshot-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 99999999;
+    cursor: crosshair;
+}
+
+#screenshot-selection {
+    position: absolute;
+    background-color: rgba(255, 255, 255, 0); /* Transparent inside */
+    border: 2px dashed #fff;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5); /* This creates the "hole" */
+}
+
+#screenshot-dimensions {
+    position: absolute;
+    top: -25px;
+    left: 0;
+    background-color: #333;
+    color: #fff;
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 4px;
+    white-space: nowrap;
+}

--- a/extension/content/capture.js
+++ b/extension/content/capture.js
@@ -1,0 +1,69 @@
+(() => {
+    if (document.getElementById('screenshot-overlay')) {
+        return; // Already active
+    }
+
+    const overlay = document.createElement('div');
+    overlay.id = 'screenshot-overlay';
+    document.body.appendChild(overlay);
+
+    const selection = document.createElement('div');
+    selection.id = 'screenshot-selection';
+
+    const dimensions = document.createElement('div');
+    dimensions.id = 'screenshot-dimensions';
+
+    let startX, startY, isSelecting = false;
+
+    overlay.addEventListener('mousedown', (e) => {
+        startX = e.clientX;
+        startY = e.clientY;
+        isSelecting = true;
+
+        selection.style.left = `${startX}px`;
+        selection.style.top = `${startY}px`;
+        selection.style.width = '0px';
+        selection.style.height = '0px';
+
+        selection.appendChild(dimensions);
+        overlay.appendChild(selection);
+    });
+
+    overlay.addEventListener('mousemove', (e) => {
+        if (!isSelecting) return;
+
+        const currentX = e.clientX;
+        const currentY = e.clientY;
+
+        const width = Math.abs(currentX - startX);
+        const height = Math.abs(currentY - startY);
+
+        selection.style.width = `${width}px`;
+        selection.style.height = `${height}px`;
+        selection.style.left = `${Math.min(startX, currentX)}px`;
+        selection.style.top = `${Math.min(startY, currentY)}px`;
+
+        dimensions.textContent = `${width}px x ${height}px`;
+    });
+
+    overlay.addEventListener('mouseup', (e) => {
+        isSelecting = false;
+        const rect = selection.getBoundingClientRect();
+
+        // Remove the overlay
+        document.body.removeChild(overlay);
+
+        // Send message to background script with the coordinates
+        chrome.runtime.sendMessage({
+            action: 'capturePartialScreenshot',
+            rect: {
+                x: rect.left,
+                y: rect.top,
+                width: rect.width,
+                height: rect.height,
+                devicePixelRatio: window.devicePixelRatio
+            }
+        });
+    });
+
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -28,6 +28,13 @@
         "mac": "Command+Shift+X"
       },
       "description": "Capture and analyze selected text on the current tab."
+    },
+    "capture-partial": {
+      "suggested_key": {
+        "default": "Alt+C",
+        "mac": "Command+Shift+C"
+      },
+      "description": "Capture a partial screenshot."
     }
   },
   "background": {


### PR DESCRIPTION
This commit introduces a new feature that allows you to capture a specific area of the screen for analysis.

- A new keyboard shortcut, `Alt+C`, has been added to initiate the partial screenshot mode.
- A user-friendly selection UI with a semi-transparent overlay and a clear selection box with dimensions is now used for capturing.
- The background script now handles cropping the screenshot and sending the partial image to me for analysis.
- The cropping logic uses the `OffscreenCanvas` API, which is the correct and modern approach for service workers.