### PR TITLE
Fix: Resolve TypeError and enhance screenshot UI

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -81,7 +81,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 return;
             }
 
-            createImageBitmap(dataUrl)
+            fetch(dataUrl)
+                .then(res => res.blob())
+                .then(blob => createImageBitmap(blob))
                 .then(imageBitmap => {
                     const dpr = request.rect.devicePixelRatio || 1;
                     const canvas = new OffscreenCanvas(request.rect.width * dpr, request.rect.height * dpr);
@@ -115,6 +117,24 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                             });
                     };
                     reader.readAsDataURL(blob);
+                });
+        });
+    } else if (request.action === 'captureScrollingScreenshot') {
+        // This is a placeholder for the scrolling logic.
+        // It's a complex feature that will be implemented in a future step.
+        console.log('Scrolling screenshot requested with rect:', request.rect);
+        // For now, just capture the visible part.
+        chrome.tabs.captureVisibleTab(null, { format: 'png' }, (dataUrl) => {
+            if (chrome.runtime.lastError || !dataUrl) {
+                console.error('Failed to capture tab:', chrome.runtime.lastError);
+                return;
+            }
+            updateIcon('loading');
+            analyzeScreenshot(dataUrl)
+                .then(analysis => handleAnalysisResponse(analysis, dataUrl))
+                .catch(error => {
+                    console.error('Error during analysis of scrolling screenshot:', error);
+                    updateIcon('inactive');
                 });
         });
     }

--- a/extension/content/capture.css
+++ b/extension/content/capture.css
@@ -27,3 +27,27 @@
     border-radius: 4px;
     white-space: nowrap;
 }
+
+#screenshot-actions {
+    position: absolute;
+    bottom: -40px;
+    right: 0;
+    display: flex;
+    gap: 8px;
+}
+
+.screenshot-button {
+    background-color: #4f46e5;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+}
+
+.screenshot-button:hover {
+    background-color: #4338ca;
+}

--- a/extension/content/capture.js
+++ b/extension/content/capture.js
@@ -48,21 +48,50 @@
 
     overlay.addEventListener('mouseup', (e) => {
         isSelecting = false;
-        const rect = selection.getBoundingClientRect();
 
-        // Remove the overlay
-        document.body.removeChild(overlay);
+        const actions = document.createElement('div');
+        actions.id = 'screenshot-actions';
 
-        // Send message to background script with the coordinates
-        chrome.runtime.sendMessage({
-            action: 'capturePartialScreenshot',
-            rect: {
-                x: rect.left,
-                y: rect.top,
-                width: rect.width,
-                height: rect.height,
-                devicePixelRatio: window.devicePixelRatio
-            }
+        const captureBtn = document.createElement('button');
+        captureBtn.className = 'screenshot-button';
+        captureBtn.textContent = 'Capture Selection';
+
+        const scrollBtn = document.createElement('button');
+        scrollBtn.className = 'screenshot-button';
+        scrollBtn.textContent = 'Capture with Scroll';
+
+        actions.appendChild(captureBtn);
+        actions.appendChild(scrollBtn);
+        selection.appendChild(actions);
+
+        captureBtn.addEventListener('click', () => {
+            const rect = selection.getBoundingClientRect();
+            chrome.runtime.sendMessage({
+                action: 'capturePartialScreenshot',
+                rect: {
+                    x: rect.left,
+                    y: rect.top,
+                    width: rect.width,
+                    height: rect.height,
+                    devicePixelRatio: window.devicePixelRatio
+                }
+            });
+            document.body.removeChild(overlay);
+        });
+
+        scrollBtn.addEventListener('click', () => {
+            const rect = selection.getBoundingClientRect();
+            chrome.runtime.sendMessage({
+                action: 'captureScrollingScreenshot',
+                rect: {
+                    x: rect.left,
+                    y: rect.top,
+                    width: rect.width,
+                    height: rect.height,
+                    devicePixelRatio: window.devicePixelRatio
+                }
+            });
+            document.body.removeChild(overlay);
         });
     });
 


### PR DESCRIPTION
This commit addresses two main points:
1.  A `TypeError` in `background.js` related to `createImageBitmap` has been resolved. The code now correctly converts the captured data URL to a Blob before passing it to `createImageBitmap`.
2.  The screenshot selection UI has been enhanced. Instead of capturing immediately on mouse up, it now displays two buttons: "Capture Selection" and "Capture with Scroll".

This fixes the bug preventing the partial screenshot from working and lays the groundwork for the future implementation of the scrolling capture feature. A placeholder has been added to `background.js` to handle the "Capture with Scroll" action, which currently captures the visible area.