### PR TITLE
feat: Refactor screenshot workflow

### DIFF
--- a/extension/content/capture.css
+++ b/extension/content/capture.css
@@ -27,27 +27,3 @@
     border-radius: 4px;
     white-space: nowrap;
 }
-
-#screenshot-actions {
-    position: absolute;
-    bottom: -40px;
-    right: 0;
-    display: flex;
-    gap: 8px;
-}
-
-.screenshot-button {
-    background-color: #4f46e5;
-    color: white;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 14px;
-    font-weight: 500;
-    transition: background-color 0.2s;
-}
-
-.screenshot-button:hover {
-    background-color: #4338ca;
-}

--- a/extension/content/capture.js
+++ b/extension/content/capture.js
@@ -48,50 +48,21 @@
 
     overlay.addEventListener('mouseup', (e) => {
         isSelecting = false;
+        const rect = selection.getBoundingClientRect();
 
-        const actions = document.createElement('div');
-        actions.id = 'screenshot-actions';
+        // Remove the overlay
+        document.body.removeChild(overlay);
 
-        const captureBtn = document.createElement('button');
-        captureBtn.className = 'screenshot-button';
-        captureBtn.textContent = 'Capture Selection';
-
-        const scrollBtn = document.createElement('button');
-        scrollBtn.className = 'screenshot-button';
-        scrollBtn.textContent = 'Capture with Scroll';
-
-        actions.appendChild(captureBtn);
-        actions.appendChild(scrollBtn);
-        selection.appendChild(actions);
-
-        captureBtn.addEventListener('click', () => {
-            const rect = selection.getBoundingClientRect();
-            chrome.runtime.sendMessage({
-                action: 'capturePartialScreenshot',
-                rect: {
-                    x: rect.left,
-                    y: rect.top,
-                    width: rect.width,
-                    height: rect.height,
-                    devicePixelRatio: window.devicePixelRatio
-                }
-            });
-            document.body.removeChild(overlay);
-        });
-
-        scrollBtn.addEventListener('click', () => {
-            const rect = selection.getBoundingClientRect();
-            chrome.runtime.sendMessage({
-                action: 'captureScrollingScreenshot',
-                rect: {
-                    x: rect.left,
-                    y: rect.top,
-                    width: rect.width,
-                    height: rect.height,
-                    devicePixelRatio: window.devicePixelRatio
-                }
-            });
-            document.body.removeChild(overlay);
+        // Send message to background script with the coordinates
+        chrome.runtime.sendMessage({
+            action: 'capturePartialScreenshot',
+            rect: {
+                x: rect.left,
+                y: rect.top,
+                width: rect.width,
+                height: rect.height,
+                devicePixelRatio: window.devicePixelRatio
+            }
         });
     });
 

--- a/extension/content/mode-selector.css
+++ b/extension/content/mode-selector.css
@@ -1,0 +1,30 @@
+#mode-selector-container {
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 12px;
+    border-radius: 8px;
+    display: flex;
+    gap: 12px;
+    z-index: 99999999;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(10px);
+}
+
+.mode-selector-button {
+    background-color: #4f46e5;
+    color: white;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+}
+
+.mode-selector-button:hover {
+    background-color: #4338ca;
+}

--- a/extension/content/mode-selector.js
+++ b/extension/content/mode-selector.js
@@ -1,0 +1,34 @@
+(() => {
+    if (document.getElementById('mode-selector-container')) {
+        return; // Already active
+    }
+
+    const container = document.createElement('div');
+    container.id = 'mode-selector-container';
+
+    const partialBtn = document.createElement('button');
+    partialBtn.className = 'mode-selector-button';
+    partialBtn.textContent = 'Partial Screenshot';
+
+    const fullPageBtn = document.createElement('button');
+    fullPageBtn.className = 'mode-selector-button';
+    fullPageBtn.textContent = 'Full Page Screenshot';
+
+    container.appendChild(partialBtn);
+    container.appendChild(fullPageBtn);
+    document.body.appendChild(container);
+
+    const removeUI = () => {
+        document.body.removeChild(container);
+    };
+
+    partialBtn.addEventListener('click', () => {
+        chrome.runtime.sendMessage({ action: 'startPartialCapture' });
+        removeUI();
+    });
+
+    fullPageBtn.addEventListener('click', () => {
+        chrome.runtime.sendMessage({ action: 'startFullPageCapture' });
+        removeUI();
+    });
+})();

--- a/extension/content/scroll-capture.js
+++ b/extension/content/scroll-capture.js
@@ -1,0 +1,37 @@
+(() => {
+    if (document.getElementById('scroll-capture-stop-btn')) {
+        return; // Already active
+    }
+
+    const stopButton = document.createElement('button');
+    stopButton.id = 'scroll-capture-stop-btn';
+    stopButton.textContent = 'Stop Capturing';
+    Object.assign(stopButton.style, {
+        position: 'fixed',
+        top: '20px',
+        right: '20px',
+        zIndex: '99999999',
+        padding: '10px 16px',
+        backgroundColor: '#e43f5a',
+        color: 'white',
+        border: 'none',
+        borderRadius: '6px',
+        cursor: 'pointer'
+    });
+    document.body.appendChild(stopButton);
+
+    let stopped = false;
+    stopButton.addEventListener('click', () => {
+        stopped = true;
+        document.body.removeChild(stopButton);
+    });
+
+    // Logic for scrolling and capturing will go here.
+    // This is a placeholder for now.
+    console.log('Scroll capture script injected.');
+
+    // For now, just send a message to the background to do a simple capture.
+    // This will be replaced with the full scrolling logic.
+    chrome.runtime.sendMessage({ action: 'captureFullPage' });
+    document.body.removeChild(stopButton); // Remove button after sending message
+})();


### PR DESCRIPTION
This commit completely refactors the screenshot functionality based on your feedback to provide a more intuitive workflow.

- **Mode Selection UI**: Pressing Alt+C now presents a clean UI with two options: "Partial Screenshot" and "Full Page Screenshot".
- **Partial Screenshot Flow**: When selected, this mode allows you to draw a box on the screen. The capture is triggered automatically on mouse release.
- **Full Page Screenshot Flow**: This option is now stubbed out with a placeholder UI and a basic capture of the visible screen. The complex logic for scrolling and stitching is deferred to a future implementation.

This change also removes the previous, more confusing UI that displayed capture buttons after the selection was made.