### PR TITLE
feat: Display results in an on-page overlay

### DIFF
--- a/extension/content/results-overlay.css
+++ b/extension/content/results-overlay.css
@@ -1,0 +1,68 @@
+#results-overlay-container {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 350px;
+    max-height: 400px;
+    background-color: rgba(26, 26, 46, 0.9); /* #1a1a2e from popup */
+    color: #e0e0e0;
+    border: 1px solid #2a3a6a;
+    border-radius: 12px;
+    z-index: 99999999;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(10px);
+}
+
+#results-overlay-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid #2a3a6a;
+}
+
+#results-overlay-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #fff;
+}
+
+#results-overlay-close-btn {
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    font-size: 24px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+    transition: color 0.2s;
+}
+
+#results-overlay-close-btn:hover {
+    color: #fff;
+}
+
+#results-overlay-content {
+    padding: 16px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.results-overlay-answer {
+    background-color: #162447;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid #2a3a6a;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.results-overlay-answer strong {
+    color: #50c878; /* Emerald green from popup */
+    margin-right: 8px;
+}

--- a/extension/content/results-overlay.js
+++ b/extension/content/results-overlay.js
@@ -1,0 +1,62 @@
+(() => {
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.action === 'displayResultsOverlay') {
+            // Remove any existing overlay
+            const existingOverlay = document.getElementById('results-overlay-container');
+            if (existingOverlay) {
+                existingOverlay.remove();
+            }
+
+            // Create the main container
+            const container = document.createElement('div');
+            container.id = 'results-overlay-container';
+
+            // Create the header
+            const header = document.createElement('div');
+            header.id = 'results-overlay-header';
+            const title = document.createElement('span');
+            title.id = 'results-overlay-title';
+            title.textContent = 'Answers Found';
+            const closeBtn = document.createElement('button');
+            closeBtn.id = 'results-overlay-close-btn';
+            closeBtn.innerHTML = '&times;';
+            header.appendChild(title);
+            header.appendChild(closeBtn);
+
+            // Create the content area
+            const content = document.createElement('div');
+            content.id = 'results-overlay-content';
+
+            // Populate with answers
+            if (request.analysis && request.analysis.questions) {
+                request.analysis.questions.forEach((q, index) => {
+                    const answerDiv = document.createElement('div');
+                    answerDiv.className = 'results-overlay-answer';
+
+                    const answerStrong = document.createElement('strong');
+                    answerStrong.textContent = `A${index + 1}:`;
+
+                    const answerText = document.createTextNode(q.direct_answer);
+
+                    answerDiv.appendChild(answerStrong);
+                    answerDiv.appendChild(answerText);
+                    content.appendChild(answerDiv);
+                });
+            } else {
+                content.textContent = 'No answers were found.';
+            }
+
+            // Assemble the overlay
+            container.appendChild(header);
+            container.appendChild(content);
+            document.body.appendChild(container);
+
+            // Add close functionality
+            closeBtn.addEventListener('click', () => {
+                container.remove();
+            });
+
+            sendResponse({ status: 'overlay displayed' });
+        }
+    });
+})();


### PR DESCRIPTION
I refactored your experience for displaying analysis results. Instead of auto-opening the extension popup, the answers are now displayed in a sticky overlay on the page itself.

- I created a new content script, `results-overlay.js`, and stylesheet, `results-overlay.css`, to handle the UI of the results overlay.
- I modified the `handleAnalysisResponse` function in `background.js` to inject these scripts and send them the analysis data.
- The overlay displays a list of answers and includes a close button.
- I removed the previous behavior of auto-opening the popup in favor of this more integrated approach.