### PR TITLE
feat: Add markdown rendering and screenshot history

### DIFF
--- a/extension/content/results-overlay.js
+++ b/extension/content/results-overlay.js
@@ -36,10 +36,10 @@
                     const answerStrong = document.createElement('strong');
                     answerStrong.textContent = `A${index + 1}:`;
 
-                    const answerText = document.createTextNode(q.direct_answer);
+                    const answerHTML = parseSimpleMarkdown(q.direct_answer);
 
                     answerDiv.appendChild(answerStrong);
-                    answerDiv.appendChild(answerText);
+                    answerDiv.innerHTML += answerHTML; // Append the parsed HTML
                     content.appendChild(answerDiv);
                 });
             } else {

--- a/extension/history/history.css
+++ b/extension/history/history.css
@@ -338,6 +338,72 @@ body {
     color: #536471;
 }
 
+.history-thumbnail {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 12px 12px 0 0;
+    cursor: pointer;
+    margin: -24px -24px 24px -24px; /* Extend to card edges */
+    border-bottom: 1px solid #eff3f4;
+}
+
+/* Image Modal Styles */
+#image-modal {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-hidden {
+    display: none !important;
+}
+
+.modal-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.modal-image {
+    max-width: 90vw;
+    max-height: 80vh;
+    border-radius: 8px;
+}
+
+.modal-close-btn {
+    position: absolute;
+    top: 20px;
+    right: 35px;
+    color: #f1f1f1;
+    font-size: 40px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.modal-new-tab-btn {
+    color: white;
+    text-decoration: none;
+    padding: 10px 20px;
+    background-color: #4f46e5;
+    border-radius: 6px;
+    transition: background-color 0.2s;
+}
+
+.modal-new-tab-btn:hover {
+    background-color: #4338ca;
+}
+
+
 @media (max-width: 768px) {
     .container {
         padding: 15px;

--- a/extension/history/history.html
+++ b/extension/history/history.html
@@ -84,6 +84,16 @@
         
         <div id="history-container"></div>
     </div>
+
+    <!-- Image Modal -->
+    <div id="image-modal" class="modal-hidden">
+        <span class="modal-close-btn">&times;</span>
+        <div class="modal-content">
+            <img class="modal-image" src="" alt="Screenshot">
+            <a href="#" class="modal-new-tab-btn" target="_blank">Open in New Tab</a>
+        </div>
+    </div>
+
     <script type="module" src="history.js"></script>
 </body>
 </html>

--- a/extension/history/history.js
+++ b/extension/history/history.js
@@ -27,6 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Load the history from storage
     loadHistoryData();
 
+    const imageModal = document.getElementById('image-modal');
+    const modalImage = document.querySelector('.modal-image');
+    const modalCloseBtn = document.querySelector('.modal-close-btn');
+    const modalNewTabBtn = document.querySelector('.modal-new-tab-btn');
+
     // Add event listeners for the controls
     searchInput.addEventListener('input', applyFilters);
     subjectFilter.addEventListener('change', applyFilters);
@@ -34,6 +39,29 @@ document.addEventListener('DOMContentLoaded', () => {
     dateFilter.addEventListener('change', applyFilters);
     exportBtn.addEventListener('click', () => exportToMarkdown(filteredHistory));
     clearBtn.addEventListener('click', clearAllHistory);
+
+    // Modal event listeners
+    historyContainer.addEventListener('click', (e) => {
+        if (e.target.classList.contains('history-thumbnail')) {
+            const analysisIndex = e.target.dataset.analysisIndex;
+            const analysis = filteredHistory[analysisIndex];
+            if (analysis && analysis.screenshotUrl) {
+                modalImage.src = analysis.screenshotUrl;
+                modalNewTabBtn.href = analysis.screenshotUrl;
+                imageModal.classList.remove('modal-hidden');
+            }
+        }
+    });
+
+    modalCloseBtn.addEventListener('click', () => {
+        imageModal.classList.add('modal-hidden');
+    });
+
+    imageModal.addEventListener('click', (e) => {
+        if (e.target === imageModal) {
+            imageModal.classList.add('modal-hidden');
+        }
+    });
 
     // Add Export to PDF button to controls bar
     const actionsBar = document.querySelector('.actions');
@@ -320,6 +348,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         historyContainer.innerHTML = history.map((analysis, analysisIndex) => {
             const timestamp = formatTimestamp(analysis.timestamp);
+            const thumbnailHtml = analysis.thumbnailUrl
+                ? `<img src="${analysis.thumbnailUrl}" alt="Screenshot thumbnail" class="history-thumbnail" data-analysis-index="${analysisIndex}">`
+                : '';
+
             let questionsHtml = '';
             
             analysis.questions.forEach((question, questionIndex) => {
@@ -348,7 +380,10 @@ document.addEventListener('DOMContentLoaded', () => {
             
             return `
                 <div class="history-analysis-card">
-                    ${questionsHtml}
+                    ${thumbnailHtml}
+                    <div class="history-card-content">
+                        ${questionsHtml}
+                    </div>
                 </div>
             `;
         }).join('');

--- a/extension/utils/markdown.js
+++ b/extension/utils/markdown.js
@@ -1,0 +1,42 @@
+function parseSimpleMarkdown(text) {
+    if (!text) {
+        return '';
+    }
+
+    let html = text;
+
+    // Sanitize by escaping HTML characters
+    html = html.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    // Bold: **text** -> <strong>text</strong>
+    html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+
+    // Unordered lists: * item -> <li>item</li>
+    const lines = html.split('\n');
+    let inList = false;
+    html = lines.map(line => {
+        if (line.startsWith('* ')) {
+            const listItem = `<li>${line.substring(2)}</li>`;
+            if (!inList) {
+                inList = true;
+                return `<ul>${listItem}`;
+            }
+            return listItem;
+        } else {
+            if (inList) {
+                inList = false;
+                return `</ul><p>${line}</p>`;
+            }
+            return `<p>${line}</p>`;
+        }
+    }).join('');
+
+    if (inList) {
+        html += '</ul>';
+    }
+
+    // Remove empty paragraphs
+    html = html.replace(/<p><\/p>/g, '');
+
+    return html;
+}


### PR DESCRIPTION
This commit implements two new major features:
1.  **Markdown in Results Overlay**: The on-page answer overlay now correctly renders markdown, displaying formatted lists and bold text. This was achieved by creating a simple, safe markdown parser and integrating it into the results display logic.
2.  **Screenshot History**: Screenshots captured via any method are now saved to the local history.
    - The history page now displays a thumbnail for each analysis that includes a screenshot.
    - Clicking a thumbnail opens a modal popup with the full-resolution image and a link to open it in a new tab.
    - To manage storage, a small thumbnail is generated in the background script and stored alongside the full-resolution image data.