### PR TITLE
fix: Resolve bugs and add image compression

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -95,7 +95,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         chrome.tabs.captureVisibleTab(null, { format: 'png' }, (dataUrl) => {
             if (dataUrl) {
                 imageStrips.push(dataUrl);
-                chrome.tabs.sendMessage(sender.tab.id, { action: 'stripCaptureComplete' });
+                // Add a delay to avoid hitting the capture quota
+                setTimeout(() => {
+                    chrome.tabs.sendMessage(sender.tab.id, { action: 'stripCaptureComplete' });
+                }, 500);
             }
         });
     } else if (request.action === 'stitchImages') {
@@ -111,7 +114,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                     currentHeight += bitmap.height;
                 });
 
-                return canvas.convertToBlob({ type: 'image/png' });
+                return canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
             })
             .then(blob => {
                 const reader = new FileReader();
@@ -154,7 +157,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                         canvas.height
                     );
 
-                    return canvas.convertToBlob({ type: 'image/png' });
+                    return canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
                 })
                 .then(blob => {
                     const reader = new FileReader();

--- a/extension/content/scroll-capture.js
+++ b/extension/content/scroll-capture.js
@@ -8,7 +8,7 @@
     stopButton.textContent = 'Stop Capturing';
     Object.assign(stopButton.style, {
         position: 'fixed',
-        top: '20px',
+        bottom: '20px',
         right: '20px',
         zIndex: '99999999',
         padding: '10px 16px',

--- a/extension/history/history.js
+++ b/extension/history/history.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const analysis = filteredHistory[analysisIndex];
             if (analysis && analysis.screenshotUrl) {
                 modalImage.src = analysis.screenshotUrl;
-                modalNewTabBtn.href = analysis.screenshotUrl;
+                // We'll handle the new tab button via its own click listener
                 imageModal.classList.remove('modal-hidden');
             }
         }
@@ -60,6 +60,20 @@ document.addEventListener('DOMContentLoaded', () => {
     imageModal.addEventListener('click', (e) => {
         if (e.target === imageModal) {
             imageModal.classList.add('modal-hidden');
+        }
+    });
+
+    modalNewTabBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const imageUrl = modalImage.src;
+        if (imageUrl) {
+            fetch(imageUrl)
+                .then(res => res.blob())
+                .then(blob => {
+                    const url = URL.createObjectURL(blob);
+                    window.open(url, '_blank');
+                    // We don't revoke the URL because the new tab needs it.
+                });
         }
     });
 


### PR DESCRIPTION
This commit addresses several bugs and introduces a new image compression feature.

- **Bug Fixes**:
  - A delay has been added to the scrolling capture loop to prevent the `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` quota error.
  - The "Open in new tab" button in the history modal now correctly opens the image by using a more reliable method (`URL.createObjectURL`).
  - The scrolling capture "Stop" button has been moved to the bottom-right of the screen as you requested.

- **New Feature**:
  - All captured images (partial, full-page, and scrolling) are now converted to compressed JPEGs before being sent for analysis or stored in history. This improves performance and reduces storage usage.